### PR TITLE
add images optimization

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,12 +28,21 @@ var gulp = require( "gulp" ),
 /** Clean */
 gulp.task( "clean", require( "del" ).bind( null, [ ".tmp", "dist" ] ) );
 
+/** Images optimization */
+gulp.task("images", function () {
+	return gulp.src( "src/img/**/*.{jpg,png,svg,gif,webp,ico}" )
+	.pipe( $.imagemin({
+		progressive: true,
+		optimizationLevel : 8
+	}))
+	.pipe(gulp.dest("dist/img"));
+});
+
 /** Copy */
 gulp.task( "copy", function() {
 	return gulp.src([
 			"src/*.{php,png,css}",
 			"src/modules/*.php",
-			"src/img/**/*.{jpg,png,svg,gif,webp,ico}",
 			"src/fonts/*.{woff,woff2,ttf,otf,eot,svg}",
 			"src/languages/*.{po,mo,pot}"
 		], {
@@ -144,6 +153,7 @@ gulp.task( "build", [
 	"stylesProduction",
 	"jshint",
 	"copy",
+	"images",
 	"uglify"
 ], function () {
   console.log("Build is finished");

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "gulp-autoprefixer": "^0.0.7",
     "gulp-concat": "^2.3.4",
     "gulp-csso": "^0.2.9",
+    "gulp-imagemin": "^2.2.1",
     "gulp-jshint": "^1.8.4",
     "gulp-livereload": "^1.2.0",
     "gulp-load-plugins": "^0.5.0",


### PR DESCRIPTION
Add 'images' task for images optimization with [gulp-imagemin](https://github.com/sindresorhus/gulp-imagemin) plug-in.

The task is added in the production environment only.

The task copy the optimized images in the 'dist/img' folder so this particular bit has been removed from the 'copy' task.