### PR TITLE
Add a gulp default task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -170,3 +170,6 @@ gulp.task( "build", [
 ], function () {
 	console.log("Build is finished");
 });
+
+/** Gulp default task */
+gulp.task( "default", ["watch"] );


### PR DESCRIPTION
Hi,

Running **gulp** without the task specified fails with the following error.

> $ gulp
[02:52:59] Using gulpfile /Applications/MAMP/htdocs/gtheme/wp-content/themes/html5blank/gulpfile.js
[02:52:59] Task 'default' is not in your gulpfile
[02:52:59] Please check the documentation for proper gulpfile formatting

I think the default task can run **watch** task.
Please let me know what you think.

Thanks