### PR TITLE
Corrected DOCTYPE declaration and Bug fix for IE7

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html <?php language_attributes(); ?> class="no-js">
 	<head>
 		<meta charset="<?php bloginfo('charset'); ?>">


### PR DESCRIPTION
Capitalized the doctype declaration "DOCTYPE" to conform to the Polyglot Markup Guidelines for HTML-Compatible XHTML Documents. This also fixes a bug in IE7 where web fonts will sometimes fail if using "lowercase" <!doctype html>

Polyglot markup uses a document type declaration (DOCTYPE) specified by section 8.1.1 of [HTML5]. In addition, the DOCTYPE conforms to the following rules:
* The string DOCTYPE is in uppercase letters.

Source reference link: http://dev.w3.org/html5/html-polyglot/html-polyglot.html#h3_doctype