### PR TITLE
Add bower to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "bower": "^1.7.7",
     "del": "^0.1.2",
     "gulp": "^3.6.0",
     "gulp-autoprefixer": "^0.0.7",


### PR DESCRIPTION
Adding **bower** to ***package.json***. It's just a thought...  For people who don't have it installed globally. If you add this then they can fallow the installation process `npm intall`, `bower instal` with not abstractions. Again, it's just a thought...