### PR TITLE
Switch from RubySass to Libsass to improve compiling speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 node_modules
 src/bower_components
+src/css/maps
 .sass-cache

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 node_modules
 src/bower_components
 src/css/maps
-.sass-cache

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,9 @@ var gulp = require( "gulp" ),
 		});
 
 		return env;
-	} ());
+	} ()),
+    /** Libsass  */
+    sass = require( "gulp-sass" );
 
 /** Clean */
 gulp.task( "clean", require( "del" ).bind( null, [ ".tmp", "dist" ] ) );
@@ -73,10 +75,7 @@ gulp.task( "copy", function() {
 /** CSS Preprocessors */
 gulp.task( "sass", function () {
 	return gulp.src( "src/css/sass/style.scss" )
-		.pipe( $.rubySass({
-			style: "expanded",
-			precision: 10
-		}))
+		.pipe( sass() )
 		.on( "error", function( e ) {
 			console.error( e );
 		})
@@ -150,7 +149,7 @@ gulp.task( "watch", [ "template", "styles", "jshint" ], function() {
 
 	/** Watch for autoprefix */
 	gulp.watch( [
-		"src/css/*.css",
+        "src/css/*.css",
 		"src/css/sass/**/*.scss"
 	], [ "styles" ] );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,9 +73,9 @@ gulp.task( "copy", function() {
 /** CSS Preprocessors */
 gulp.task( "sass", function () {
 	return gulp.src( "src/css/sass/style.scss" )
-		.pipe($.sourcemaps.init())
-		.pipe($.sass() )
-		.pipe($.sourcemaps.write('./maps'))
+		.pipe( $.sourcemaps.init() )
+		.pipe( $.sass() )
+		.pipe( $.sourcemaps.write( "./maps" ) )
 		.on( "error", function( e ) {
 			console.error( e );
 		})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,6 @@ var gulp = require( "gulp" ),
 		return env;
 	} ());
 
-
 /** Clean */
 gulp.task( "clean", require( "del" ).bind( null, [ ".tmp", "dist" ] ) );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,11 +51,7 @@ var gulp = require( "gulp" ),
 		});
 
 		return env;
-	} ()),
-    /** Libsass  */
-    sass = require( "gulp-sass" ),
-    /** SourceMap Generator */
-    sourcemaps = require('gulp-sourcemaps');
+	} ());
 
 
 /** Clean */
@@ -78,9 +74,9 @@ gulp.task( "copy", function() {
 /** CSS Preprocessors */
 gulp.task( "sass", function () {
 	return gulp.src( "src/css/sass/style.scss" )
-		.pipe(sourcemaps.init())
-		.pipe( sass() )
-		.pipe(sourcemaps.write('./maps'))
+		.pipe($.sourcemaps.init())
+		.pipe($.sass() )
+		.pipe($.sourcemaps.write('./maps'))
 		.on( "error", function( e ) {
 			console.error( e );
 		})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,10 @@ var gulp = require( "gulp" ),
 		return env;
 	} ()),
     /** Libsass  */
-    sass = require( "gulp-sass" );
+    sass = require( "gulp-sass" ),
+    /** SourceMap Generator */
+    sourcemaps = require('gulp-sourcemaps');
+
 
 /** Clean */
 gulp.task( "clean", require( "del" ).bind( null, [ ".tmp", "dist" ] ) );
@@ -75,7 +78,9 @@ gulp.task( "copy", function() {
 /** CSS Preprocessors */
 gulp.task( "sass", function () {
 	return gulp.src( "src/css/sass/style.scss" )
+		.pipe(sourcemaps.init())
 		.pipe( sass() )
+		.pipe(sourcemaps.write('./maps'))
 		.on( "error", function( e ) {
 			console.error( e );
 		})

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,7 @@ gulp.task( "watch", [ "template", "styles", "jshint" ], function() {
 
 	/** Watch for autoprefix */
 	gulp.watch( [
-        "src/css/*.css",
+		"src/css/*.css",
 		"src/css/sass/**/*.scss"
 	], [ "styles" ] );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,7 +75,7 @@ gulp.task( "sass", function () {
 	return gulp.src( "src/css/sass/style.scss" )
 		.pipe( $.sourcemaps.init() )
 		.pipe( $.sass() )
-		.pipe( $.sourcemaps.write( "./maps" ) )
+		.pipe( $.sourcemaps.write( "." ) )
 		.on( "error", function( e ) {
 			console.error( e );
 		})

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "gulp-jshint": "^1.8.4",
     "gulp-livereload": "^1.2.0",
     "gulp-load-plugins": "^0.5.0",
-    "gulp-ruby-sass": "^0.7.1",
+    "gulp-sass": "^2.2.0",
     "gulp-template": "^1.0.0",
     "gulp-uglify": "^1.0.0",
     "jshint-stylish": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "gulp-livereload": "^1.2.0",
     "gulp-load-plugins": "^0.5.0",
     "gulp-sass": "^2.2.0",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-template": "^1.0.0",
     "gulp-uglify": "^1.0.0",
     "jshint-stylish": "^0.4.0"


### PR DESCRIPTION
I had some project with Laravel, as you know Laravel's gulp uses libsass to compile sass files.

When I start working with **Ruby Sass** used by HTML5Blank I found it **SUPER SLOW** compared to gulp-sass used by Laravel.

I googled the issue if there is any problem with my ruby configuration and  I found tons of sites that say Libsass is noticeably faster than ruby sass. Here are some examples:

> http://sassbreak.com/ruby-sass-libsass-differences/ 
> https://benfrain.com/lightning-fast-sass-compiling-with-libsass-node-sass-and-grunt-sass/

I suggest html5blank to switch to Libsass.