### PR TITLE
fix watch styles task for gulp

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,7 +150,6 @@ gulp.task( "watch", [ "template", "styles", "jshint" ], function() {
 
 	/** Watch for autoprefix */
 	gulp.watch( [
-		"src/css/*.css",
 		"src/css/sass/**/*.scss"
 	], [ "styles" ] );
 


### PR DESCRIPTION
I just found an unnecessary watch on CSS stylesheet files.

Since css files are generated using scss files, watching changes on css files will result in triggering **Styles Task** one more time.