### PR TITLE
Some function.php code cleanup

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -33,13 +33,13 @@ if (function_exists('add_theme_support'))
     add_image_size('custom-size', 700, 200, true); // Custom Thumbnail Size call using the_post_thumbnail('custom-size');
 
     // Add Support for Custom Backgrounds - Uncomment below if you're going to use
-    /*add_theme_support('custom-background', array(
+    /*add_theme_support('custom-background', [
     'default-color' => 'FFF',
     'default-image' => get_template_directory_uri() . '/img/bg.jpg'
-    ));*/
+    ]);*/
 
     // Add Support for Custom Header - Uncomment below if you're going to use
-    /*add_theme_support('custom-header', array(
+    /*add_theme_support('custom-header', ]
     'default-image'          => get_template_directory_uri() . '/img/headers/default.jpg',
     'header-text'            => false,
     'default-text-color'     => '000',
@@ -49,7 +49,7 @@ if (function_exists('add_theme_support'))
     'wp-head-callback'       => $wphead_cb,
     'admin-head-callback'    => $adminhead_cb,
     'admin-preview-callback' => $adminpreview_cb
-    ));*/
+    ]);*/
 
     // Enables post and comment RSS feed links to head
     add_theme_support('automatic-feed-links');
@@ -65,8 +65,7 @@ if (function_exists('add_theme_support'))
 // HTML5 Blank navigation
 function html5blank_nav()
 {
-    wp_nav_menu(
-    array(
+    wp_nav_menu(array(
         'theme_location'  => 'header-menu',
         'menu'            => '',
         'container'       => 'div',
@@ -83,45 +82,39 @@ function html5blank_nav()
         'items_wrap'      => '<ul>%3$s</ul>',
         'depth'           => 0,
         'walker'          => ''
-        )
-    );
+    ));
 }
 
 // Load HTML5 Blank scripts (header.php)
 function html5blank_header_scripts()
 {
-    if ($GLOBALS['pagenow'] != 'wp-login.php' && !is_admin()) {
-        if (HTML5_DEBUG) {
-            // jQuery
-            wp_deregister_script('jquery');
-            wp_register_script('jquery', get_template_directory_uri() . '/bower_components/jquery/dist/jquery.js', array(), '1.11.1');
+    $HTML5_URI = get_template_directory_uri();
 
-            // Conditionizr
-            wp_register_script('conditionizr', get_template_directory_uri() . '/js/lib/conditionizr-4.3.0.min.js', array(), '4.3.0');
+    if ( is_admin() || $GLOBALS['pagenow'] == 'wp-login.php' )  return;
 
-            // Modernizr
-            wp_register_script('modernizr', get_template_directory_uri() . '/bower_components/modernizr/modernizr.js', array(), '2.8.3');
+    if (HTML5_DEBUG) {
+        // jQuery
+        wp_deregister_script('jquery');
+        wp_register_script('jquery', "{$HTML5_URI}/bower_components/jquery/dist/jquery.min.js", array(), '1.11.1');
 
-            // Custom scripts
-            wp_register_script(
-                'html5blankscripts',
-                get_template_directory_uri() . '/js/scripts.js',
-                array(
-                    'conditionizr',
-                    'modernizr',
-                    'jquery'),
-                '1.0.0');
+        // Conditionizr
+        wp_register_script('conditionizr', "{$HTML5_URI}/js/lib/conditionizr-4.3.0.min.js", array(), '4.3.0');
 
-            // Enqueue Scripts
-            wp_enqueue_script('html5blankscripts');
+        // Modernizr
+        wp_register_script('modernizr', "{$HTML5_URI}/bower_components/modernizr/modernizr.js", array(), '2.8.3');
+
+        // Custom scripts
+        wp_register_script( 'html5blankscripts', "{$HTML5_URI}/js/scripts.js",  array('conditionizr', 'modernizr', 'jquery'), '1.0.0');
+
+        // Enqueue Scripts
+        wp_enqueue_script('html5blankscripts');
 
         // If production
-        } else {
-            // Scripts minify
-            wp_register_script('html5blankscripts-min', get_template_directory_uri() . '/js/scripts.min.js', array(), '1.0.0');
-            // Enqueue Scripts
-            wp_enqueue_script('html5blankscripts-min');
-        }
+    } else {
+        // Scripts minify
+        wp_register_script('html5blankscripts-min', "{$HTML5_URI}/js/scripts.min.js", array(), '1.0.0');
+        // Enqueue Scripts
+        wp_enqueue_script('html5blankscripts-min');
     }
 }
 
@@ -138,18 +131,20 @@ function html5blank_conditional_scripts()
 // Load HTML5 Blank styles
 function html5blank_styles()
 {
+    $HTML5_URI = get_template_directory_uri();
+
     if (HTML5_DEBUG) {
         // normalize-css
-        wp_register_style('normalize', get_template_directory_uri() . '/bower_components/normalize.css/normalize.css', array(), '3.0.1');
+        wp_register_style('normalize', "{$HTML5_URI}/bower_components/normalize.css/normalize.css", array(), '3.0.1');
 
         // Custom CSS
-        wp_register_style('html5blank', get_template_directory_uri() . '/style.css', array('normalize'), '1.0');
+        wp_register_style('html5blank',  "{$HTML5_URI}/style.css", array('normalize'), '1.0');
 
         // Register CSS
         wp_enqueue_style('html5blank');
     } else {
         // Custom CSS
-        wp_register_style('html5blankcssmin', get_template_directory_uri() . '/style.css', array(), '1.0');
+        wp_register_style('html5blankcssmin', "{$HTML5_URI}/style.css", array(), '1.0');
         // Register CSS
         wp_enqueue_style('html5blankcssmin');
     }
@@ -163,13 +158,6 @@ function register_html5_menu()
         'sidebar-menu' => __('Sidebar Menu', 'html5blank'), // Sidebar Navigation
         'extra-menu' => __('Extra Menu', 'html5blank') // Extra Navigation if needed (duplicate as many as you need!)
     ));
-}
-
-// Remove the <div> surrounding the dynamic navigation to cleanup markup
-function my_wp_nav_menu_args($args = '')
-{
-    $args['container'] = false;
-    return $args;
 }
 
 // Remove Injected classes, ID's and Page ID's from Navigation <li> items
@@ -202,37 +190,23 @@ function add_slug_to_body_class($classes)
     return $classes;
 }
 
-// Remove the width and height attributes from inserted images
-function remove_width_attribute( $html ) {
-   $html = preg_replace( '/(width|height)="\d*"\s/', "", $html );
-   return $html;
-}
-
 
 // If Dynamic Sidebar Exists
 if (function_exists('register_sidebar'))
 {
-    // Define Sidebar Widget Area 1
-    register_sidebar(array(
-        'name' => __('Widget Area 1', 'html5blank'),
-        'description' => __('Description for this widget-area...', 'html5blank'),
-        'id' => 'widget-area-1',
-        'before_widget' => '<div id="%1$s" class="%2$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h3>',
-        'after_title' => '</h3>'
-    ));
-
-    // Define Sidebar Widget Area 2
-    register_sidebar(array(
-        'name' => __('Widget Area 2', 'html5blank'),
-        'description' => __('Description for this widget-area...', 'html5blank'),
-        'id' => 'widget-area-2',
-        'before_widget' => '<div id="%1$s" class="%2$s">',
-        'after_widget' => '</div>',
-        'before_title' => '<h3>',
-        'after_title' => '</h3>'
-    ));
+    // Define Sidebar Widget Area as many as you like
+    $numberOfWidgetAreas = 2;
+    for ($i = 1; $i <= $numberOfWidgetAreas; ++$i) {
+        register_sidebar(array(
+            'name' => __("Widget Area $i", 'html5blank'),
+            'description' => __('Description for this widget-area...', 'html5blank'),
+            'id' => "widget-area-$i",
+            'before_widget' => '<div id="%1$s" class="%2$s">',
+            'after_widget' => '</div>',
+            'before_title' => '<h3>',
+            'after_title' => '</h3>'
+        ));
+    }
 }
 
 // Remove wp_head() injected Recent Comment styles
@@ -294,22 +268,10 @@ function html5_blank_view_article($more)
     return '... <a class="view-article" href="' . get_permalink($post->ID) . '">' . __('View Article', 'html5blank') . '</a>';
 }
 
-// Remove Admin bar
-function remove_admin_bar()
-{
-    return false;
-}
 
-// Remove 'text/css' from our enqueued stylesheet
-function html5_style_remove($tag)
-{
-    return preg_replace('~\s+type=["\'][^"\']++["\']~', '', $tag);
-}
-
-// Remove thumbnail width and height dimensions that prevent fluid images in the_thumbnail
-function remove_thumbnail_dimensions( $html )
-{
-    $html = preg_replace('/(width|height)=\"\d*\"\s/', "", $html);
+// Remove the width and height attributes from inserted images
+function remove_width_attribute( $html ) {
+    $html = preg_replace( '/(width|height)="\d*"\s/', "", $html );
     return $html;
 }
 
@@ -324,10 +286,8 @@ function html5blankgravatar ($avatar_defaults)
 // Threaded Comments
 function enable_threaded_comments()
 {
-    if (!is_admin()) {
-        if (is_singular() AND comments_open() AND (get_option('thread_comments') == 1)) {
-            wp_enqueue_script('comment-reply');
-        }
+    if ( !is_admin() AND is_singular() AND comments_open() AND (get_option('thread_comments') == 1)) {
+        wp_enqueue_script('comment-reply');
     }
 }
 
@@ -344,23 +304,23 @@ function html5blankcomments($comment, $args, $depth)
         $tag = 'li';
         $add_below = 'div-comment';
     }
-?>
+    ?>
     <!-- heads up: starting < for the html tag (li or div) in the next line: -->
     <<?php echo $tag ?> <?php comment_class(empty( $args['has_children'] ) ? '' : 'parent') ?> id="comment-<?php comment_ID() ?>">
     <?php if ( 'div' != $args['style'] ) : ?>
     <div id="div-comment-<?php comment_ID() ?>" class="comment-body">
-    <?php endif; ?>
+<?php endif; ?>
     <div class="comment-author vcard">
-    <?php if ($args['avatar_size'] != 0) echo get_avatar( $comment, $args['avatar_size'] ); ?>
-    <?php printf(__('<cite class="fn">%s</cite> <span class="says">says:</span>'), get_comment_author_link()) ?>
+        <?php if ($args['avatar_size'] != 0) echo get_avatar( $comment, $args['avatar_size'] ); ?>
+        <?php printf(__('<cite class="fn">%s</cite> <span class="says">says:</span>'), get_comment_author_link()) ?>
     </div>
-<?php if ($comment->comment_approved == '0') : ?>
+    <?php if ($comment->comment_approved == '0') : ?>
     <em class="comment-awaiting-moderation"><?php _e('Your comment is awaiting moderation.') ?></em>
     <br />
 <?php endif; ?>
 
     <div class="comment-meta commentmetadata"><a href="<?php echo htmlspecialchars( get_comment_link( $comment->comment_ID ) ) ?>">
-        <?php
+            <?php
             printf( __('%1$s at %2$s'), get_comment_date(),  get_comment_time()) ?></a><?php edit_comment_link(__('(Edit)'),'  ','' );
         ?>
     </div>
@@ -368,64 +328,13 @@ function html5blankcomments($comment, $args, $depth)
     <?php comment_text() ?>
 
     <div class="reply">
-    <?php comment_reply_link(array_merge( $args, array('add_below' => $add_below, 'depth' => $depth, 'max_depth' => $args['max_depth']))) ?>
+        <?php comment_reply_link(array_merge( $args, array('add_below' => $add_below, 'depth' => $depth, 'max_depth' => $args['max_depth']))) ?>
     </div>
     <?php if ( 'div' != $args['style'] ) : ?>
     </div>
-    <?php endif; ?>
+<?php endif; ?>
 <?php }
 
-/*------------------------------------*\
-    Actions + Filters + ShortCodes
-\*------------------------------------*/
-
-// Add Actions
-add_action('init', 'html5blank_header_scripts'); // Add Custom Scripts to wp_head
-add_action('wp_print_scripts', 'html5blank_conditional_scripts'); // Add Conditional Page Scripts
-add_action('get_header', 'enable_threaded_comments'); // Enable Threaded Comments
-add_action('wp_enqueue_scripts', 'html5blank_styles'); // Add Theme Stylesheet
-add_action('init', 'register_html5_menu'); // Add HTML5 Blank Menu
-add_action('init', 'create_post_type_html5'); // Add our HTML5 Blank Custom Post Type
-add_action('widgets_init', 'my_remove_recent_comments_style'); // Remove inline Recent Comment Styles from wp_head()
-add_action('init', 'html5wp_pagination'); // Add our HTML5 Pagination
-
-// Remove Actions
-remove_action('wp_head', 'feed_links_extra', 3); // Display the links to the extra feeds such as category feeds
-remove_action('wp_head', 'feed_links', 2); // Display the links to the general feeds: Post and Comment Feed
-remove_action('wp_head', 'rsd_link'); // Display the link to the Really Simple Discovery service endpoint, EditURI link
-remove_action('wp_head', 'wlwmanifest_link'); // Display the link to the Windows Live Writer manifest file.
-remove_action('wp_head', 'wp_generator'); // Display the XHTML generator that is generated on the wp_head hook, WP version
-remove_action('wp_head', 'rel_canonical');
-remove_action('wp_head', 'wp_shortlink_wp_head', 10, 0);
-
-// Add Filters
-add_filter('avatar_defaults', 'html5blankgravatar'); // Custom Gravatar in Settings > Discussion
-add_filter('body_class', 'add_slug_to_body_class'); // Add slug to body class (Starkers build)
-add_filter('widget_text', 'do_shortcode'); // Allow shortcodes in Dynamic Sidebar
-add_filter('widget_text', 'shortcode_unautop'); // Remove <p> tags in Dynamic Sidebars (better!)
-add_filter('wp_nav_menu_args', 'my_wp_nav_menu_args'); // Remove surrounding <div> from WP Navigation
-// add_filter('nav_menu_css_class', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> injected classes (Commented out by default)
-// add_filter('nav_menu_item_id', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> injected ID (Commented out by default)
-// add_filter('page_css_class', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> Page ID's (Commented out by default)
-add_filter('the_category', 'remove_category_rel_from_category_list'); // Remove invalid rel attribute
-add_filter('the_excerpt', 'shortcode_unautop'); // Remove auto <p> tags in Excerpt (Manual Excerpts only)
-add_filter('the_excerpt', 'do_shortcode'); // Allows Shortcodes to be executed in Excerpt (Manual Excerpts only)
-add_filter('excerpt_more', 'html5_blank_view_article'); // Add 'View Article' button instead of [...] for Excerpts
-add_filter('show_admin_bar', 'remove_admin_bar'); // Remove Admin bar
-add_filter('style_loader_tag', 'html5_style_remove'); // Remove 'text/css' from enqueued stylesheet
-add_filter('post_thumbnail_html', 'remove_thumbnail_dimensions', 10); // Remove width and height dynamic attributes to thumbnails
-add_filter('post_thumbnail_html', 'remove_width_attribute', 10 ); // Remove width and height dynamic attributes to post images
-add_filter('image_send_to_editor', 'remove_width_attribute', 10 ); // Remove width and height dynamic attributes to post images
-
-// Remove Filters
-remove_filter('the_excerpt', 'wpautop'); // Remove <p> tags from Excerpt altogether
-
-// Shortcodes
-add_shortcode('html5_shortcode_demo', 'html5_shortcode_demo'); // You can place [html5_shortcode_demo] in Pages, Posts now.
-add_shortcode('html5_shortcode_demo_2', 'html5_shortcode_demo_2'); // Place [html5_shortcode_demo_2] in Pages, Posts now.
-
-// Shortcodes above would be nested like this -
-// [html5_shortcode_demo] [html5_shortcode_demo_2] Here's the page title! [/html5_shortcode_demo_2] [/html5_shortcode_demo]
 
 /*------------------------------------*\
     Custom Post Types
@@ -436,20 +345,19 @@ function create_post_type_html5()
 {
     register_taxonomy_for_object_type('category', 'html5-blank'); // Register Taxonomies for Category
     register_taxonomy_for_object_type('post_tag', 'html5-blank');
-    register_post_type('html5-blank', // Register Custom Post Type
-        array(
+    register_post_type('html5-blank', array( // Register Custom Post Type
         'labels' => array(
-            'name' => __('HTML5 Blank Custom Post', 'html5blank'), // Rename these to suit
-            'singular_name' => __('HTML5 Blank Custom Post', 'html5blank'),
-            'add_new' => __('Add New', 'html5blank'),
-            'add_new_item' => __('Add New HTML5 Blank Custom Post', 'html5blank'),
-            'edit' => __('Edit', 'html5blank'),
-            'edit_item' => __('Edit HTML5 Blank Custom Post', 'html5blank'),
-            'new_item' => __('New HTML5 Blank Custom Post', 'html5blank'),
-            'view' => __('View HTML5 Blank Custom Post', 'html5blank'),
-            'view_item' => __('View HTML5 Blank Custom Post', 'html5blank'),
-            'search_items' => __('Search HTML5 Blank Custom Post', 'html5blank'),
-            'not_found' => __('No HTML5 Blank Custom Posts found', 'html5blank'),
+            'name'               => __('HTML5 Blank Custom Post', 'html5blank'), // Rename these to suit
+            'singular_name'      => __('HTML5 Blank Custom Post', 'html5blank'),
+            'add_new'            => __('Add New', 'html5blank'),
+            'add_new_item'       => __('Add New HTML5 Blank Custom Post', 'html5blank'),
+            'edit'               => __('Edit', 'html5blank'),
+            'edit_item'          => __('Edit HTML5 Blank Custom Post', 'html5blank'),
+            'new_item'           => __('New HTML5 Blank Custom Post', 'html5blank'),
+            'view'               => __('View HTML5 Blank Custom Post', 'html5blank'),
+            'view_item'          => __('View HTML5 Blank Custom Post', 'html5blank'),
+            'search_items'       => __('Search HTML5 Blank Custom Post', 'html5blank'),
+            'not_found'          => __('No HTML5 Blank Custom Posts found', 'html5blank'),
             'not_found_in_trash' => __('No HTML5 Blank Custom Posts found in Trash', 'html5blank')
         ),
         'public' => true,
@@ -484,3 +392,58 @@ function html5_shortcode_demo_2($atts, $content = null) // Demo Heading H2 short
 {
     return '<h2>' . $content . '</h2>';
 }
+
+
+/*------------------------------------*\
+    Actions + Filters + ShortCodes
+\*------------------------------------*/
+
+// Add Actions
+add_action('init', 'html5blank_header_scripts'); // Add Custom Scripts to wp_head
+add_action('wp_print_scripts', 'html5blank_conditional_scripts'); // Add Conditional Page Scripts
+add_action('get_header', 'enable_threaded_comments'); // Enable Threaded Comments
+add_action('wp_enqueue_scripts', 'html5blank_styles'); // Add Theme Stylesheet
+add_action('init', 'register_html5_menu'); // Add HTML5 Blank Menu
+add_action('init', 'create_post_type_html5'); // Add our HTML5 Blank Custom Post Type
+add_action('widgets_init', 'my_remove_recent_comments_style'); // Remove inline Recent Comment Styles from wp_head()
+add_action('init', 'html5wp_pagination'); // Add our HTML5 Pagination
+
+// Remove Actions
+remove_action('wp_head', 'feed_links_extra', 3); // Display the links to the extra feeds such as category feeds
+remove_action('wp_head', 'feed_links', 2); // Display the links to the general feeds: Post and Comment Feed
+remove_action('wp_head', 'rsd_link'); // Display the link to the Really Simple Discovery service endpoint, EditURI link
+remove_action('wp_head', 'wlwmanifest_link'); // Display the link to the Windows Live Writer manifest file.
+remove_action('wp_head', 'wp_generator'); // Display the XHTML generator that is generated on the wp_head hook, WP version
+remove_action('wp_head', 'rel_canonical');
+remove_action('wp_head', 'wp_shortlink_wp_head', 10);
+
+// Add Filters
+add_filter('avatar_defaults', 'html5blankgravatar'); // Custom Gravatar in Settings > Discussion
+add_filter('body_class', 'add_slug_to_body_class'); // Add slug to body class (Starkers build)
+add_filter('widget_text', 'do_shortcode'); // Allow shortcodes in Dynamic Sidebar
+add_filter('widget_text', 'shortcode_unautop'); // Remove <p> tags in Dynamic Sidebars (better!)
+// add_filter('nav_menu_css_class', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> injected classes (Commented out by default)
+// add_filter('nav_menu_item_id', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> injected ID (Commented out by default)
+// add_filter('page_css_class', 'my_css_attributes_filter', 100, 1); // Remove Navigation <li> Page ID's (Commented out by default)
+add_filter('the_category', 'remove_category_rel_from_category_list'); // Remove invalid rel attribute
+add_filter('the_excerpt', 'shortcode_unautop'); // Remove auto <p> tags in Excerpt (Manual Excerpts only)
+add_filter('the_excerpt', 'do_shortcode'); // Allows Shortcodes to be executed in Excerpt (Manual Excerpts only)
+add_filter('excerpt_more', 'html5_blank_view_article'); // Add 'View Article' button instead of [...] for Excerpts
+add_filter('post_thumbnail_html', 'remove_width_attribute', 10 ); // Remove width and height dynamic attributes to post images
+add_filter('image_send_to_editor', 'remove_width_attribute', 10 ); // Remove width and height dynamic attributes to post images
+add_filter('wp_nav_menu_args', function ($args = '') { $args['container'] = false; return $args; } ); // Remove surrounding <div> from WP Navigation
+add_filter('show_admin_bar', function () { return false; }); // Remove Admin bar
+// Remove 'text/css' from enqueued stylesheet
+add_filter('style_loader_tag', function ($tag) { return preg_replace('~\s+type=["\'][^"\']++["\']~', '', $tag); });
+// Remove width and height dynamic attributes to thumbnails
+add_filter('post_thumbnail_html', function ($html) { $html = preg_replace('/(width|height)=\"\d*\"\s/', "", $html); return $html; }, 10);
+
+// Remove Filters
+remove_filter('the_excerpt', 'wpautop'); // Remove <p> tags from Excerpt altogether
+
+// Shortcodes
+add_shortcode('html5_shortcode_demo', 'html5_shortcode_demo'); // You can place [html5_shortcode_demo] in Pages, Posts now.
+add_shortcode('html5_shortcode_demo_2', 'html5_shortcode_demo_2'); // Place [html5_shortcode_demo_2] in Pages, Posts now.
+
+// Shortcodes above would be nested like this -
+// [html5_shortcode_demo] [html5_shortcode_demo_2] Here's the page title! [/html5_shortcode_demo_2] [/html5_shortcode_demo]


### PR DESCRIPTION
Some simple functions are used as a closure to remove little single used functions away.

A little cleanup inside _html5blank_styles_ and _html5blank_header_scripts_ functions.

I prefer using short form arrays, but they are not supported in php < 5.4... and as you may already know, wordpress still supports php 5.3