### PR TITLE
add aria-label to main element

### DIFF
--- a/src/404.php
+++ b/src/404.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/archive.php
+++ b/src/archive.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/author.php
+++ b/src/author.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/category.php
+++ b/src/category.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/index.php
+++ b/src/index.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/page.php
+++ b/src/page.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/search.php
+++ b/src/search.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/single.php
+++ b/src/single.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 	<!-- section -->
 	<section>
 

--- a/src/tag.php
+++ b/src/tag.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 

--- a/src/template-demo.php
+++ b/src/template-demo.php
@@ -1,6 +1,6 @@
 <?php /* Template Name: Demo Page Template */ get_header(); ?>
 
-	<main role="main">
+	<main role="main" aria-label="Content">
 		<!-- section -->
 		<section>
 


### PR DESCRIPTION
This is a small quality of life update for screen readers, so now the <main> element will be announced as ‘main content’ rather than just ‘main’, adding a bit of extra context for these users.