### PR TITLE
LiveReload fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,7 +135,8 @@ gulp.task( "envProduction", function() {
 
 /** Livereload */
 gulp.task( "watch", [ "template", "styles", "jshint" ], function() {
-	var server = $.livereload();
+	var server = $.livereload;
+	server.listen();
 
 	/** Watch for livereoad */
 	gulp.watch([


### PR DESCRIPTION
It seems there was a minor change in the API in one of the last updates of `gulp-livereload`