### PR TITLE
Check if WP_Widget_Recent_Comments key is set

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -242,10 +242,13 @@ if (function_exists('register_sidebar'))
 function my_remove_recent_comments_style()
 {
     global $wp_widget_factory;
-    remove_action('wp_head', array(
-        $wp_widget_factory->widgets['WP_Widget_Recent_Comments'],
-        'recent_comments_style'
-    ));
+    
+    if (isset($wp_widget_factory->widgets['WP_Widget_Recent_Comments'])) {
+        remove_action('wp_head', array(
+            $wp_widget_factory->widgets['WP_Widget_Recent_Comments'],
+            'recent_comments_style'
+        ));
+    }
 }
 
 // Pagination for paged posts, Page 1, Page 2, Page 3, with Next and Previous Links, No plugin


### PR DESCRIPTION
Check for the existence of the WP_Widget_Recent_Comments key in the widget factory before attempting to remove it. Fixes a compatibility issue with the Disable Comments plugin [https://wordpress.org/plugins/disable-comments/]