### PR TITLE
Move modernizr build to gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Powerful shell for rapidly deploying your WordPress projects.
 
 * Go to the Wordpress' theme folder (`.../wp-content/themes`)
 * In CLI, run: `git clone https://github.com/toddmotto/html5blank.git`
-* `cd html5blank` and then `npm install` and then `npm run modernizr` (you'll need gulp install as well)
+* `cd html5blank` and then `npm install` (you'll need gulp install as well)
 * `gulp watch` will enable `livereload` and development version
 * `gulp build` for distribute version with minified `js` and `css` files
 * NOTE: `src` and `dist` folders can live happily together inside the same folder (`html5blank`) that in the `theme` folder. You'll have two different instances of the theme within `Appearance > Themes` panel inside the admin

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -120,6 +120,17 @@ gulp.task( "template", function() {
         .pipe( gulp.dest( "src/modules" ) );
 });
 
+/** Modernizr **/
+gulp.task( "modernizr", function() {
+	var modernizr = require( "modernizr" ),
+		config = require( "./node_modules/modernizr/lib/config-all"),
+		fs = require( "fs" );
+
+		modernizr.build(config, function(code) {
+			fs.writeFile("./src/js/lib/modernizr.js", code);
+		});
+});
+
 /** Uglify */
 gulp.task( "uglify", function() {
 	return gulp.src( uglifySrc )
@@ -164,6 +175,7 @@ gulp.task( "build", [
 	"clean",
 	"template",
 	"styles",
+	"modernizr",
 	"jshint",
 	"copy",
 	"uglify"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     }
   ],
   "scripts": {
-    "modernizr": "cd node_modules/modernizr && ./bin/modernizr -c lib/config-all.json && mv ./modernizr.js ../../src/js/lib/modernizr.js"
+    "modernizr": "gulp modernizr"
   },
   "dependencies": {
     "jquery": "^1.11.1",
@@ -124,7 +124,7 @@
   },
   "devDependencies": {
     "del": "^2.2.2",
-    "gulp": "^3.6.0",
+    "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-concat": "^2.3.4",
     "gulp-csso": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "devDependencies": {
     "del": "^2.2.2",
-    "gulp": "^3.9.1",
+    "gulp": "^3.6.0",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-concat": "^2.3.4",
     "gulp-csso": "^2.0.0",


### PR DESCRIPTION
By moving the build of the modernizer JS module to the gulp tasks this fixes the bash/sh dependency so that Windows machines can have a consistent build process.

This is intended to resolve Issue #174

Tested 'npm run modernizr', 'gulp modernizr', and 'gulp build' on Win7 and Linux Mint 18.1 